### PR TITLE
fix: Update user role assignment logic in RegisterUserUseCase

### DIFF
--- a/src/modules/auth/application/useCases/registerUser/RegisterUserResponseDto.ts
+++ b/src/modules/auth/application/useCases/registerUser/RegisterUserResponseDto.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "../../../domain/entities/User";
+export type UserRole = "ADMIN" | "TEAM_MEMBER";
 
 export interface RegisterUserResponseDto {
   id: string;


### PR DESCRIPTION
- Modified role assignment to only assign ADMIN role in development environment.
- Updated import statement to include UserRole from RegisterUserResponseDto.
- Enhanced logging to indicate when the first user is detected in development mode.